### PR TITLE
[Merged by Bors] - Improve CLI help and error messages

### DIFF
--- a/crates/model/src/pipe/color.rs
+++ b/crates/model/src/pipe/color.rs
@@ -71,7 +71,7 @@ impl FromStr for ColorMode {
             "ansi" => Self::Ansi,
             "rgb" => Self::Rgb,
             "none" => Self::None,
-            _ => anyhow::bail!(r#"unknown color mode (expected “ansi”, “rgb” or “none”)"#),
+            _ => anyhow::bail!("unknown color mode"),
         })
     }
 }
@@ -94,9 +94,7 @@ impl FromStr for Palette {
             "darker" => Self::Darker,
             "pastel" => Self::Pastel,
             "matrix" => Self::Matrix,
-            _ => anyhow::bail!(
-                r#"unknown palette (expected “default”, “darker”, “pastel” or “matrix”)"#,
-            ),
+            _ => anyhow::bail!("unknown palette"),
         })
     }
 }

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -8,11 +8,11 @@ use structopt::StructOpt;
 #[derive(Serialize, Deserialize, Default, StructOpt)]
 #[structopt(name = "pipes-rs")]
 pub(crate) struct Config {
-    /// “ansi”, “rgb” or “none”
+    /// what kind of terminal coloring to use
     #[structopt(short, long, possible_values = &["ansi", "rgb", "none"])]
     color_mode: Option<ColorMode>,
 
-    /// “default”, “darker”, “pastel” or “matrix”
+    /// the color palette used assign colors to pipes
     #[structopt(long, possible_values = &["default", "darker", "pastel", "matrix"])]
     palette: Option<Palette>,
 

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -28,12 +28,12 @@ pub(crate) struct Config {
     #[structopt(short, long)]
     kinds: Option<PresetKindSet>,
 
-    /// whether to use bold (true/false)
-    #[structopt(short, long)]
+    /// whether to use bold
+    #[structopt(short, long, possible_values = &["true", "false"])]
     bold: Option<bool>,
 
-    /// whether pipes should retain style after hitting the edge (true/false)
-    #[structopt(short, long)]
+    /// whether pipes should retain style after hitting the edge
+    #[structopt(short, long, possible_values = &["true", "false"])]
     inherit_style: Option<bool>,
 
     /// number of pipes

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -3,10 +3,11 @@ use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, Xdg};
 use model::pipe::{ColorMode, Palette, PresetKind, PresetKindSet};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fs, path::PathBuf, time::Duration};
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 #[derive(Serialize, Deserialize, Default, StructOpt)]
-#[structopt(name = "pipes-rs")]
+#[structopt(name = "pipes-rs", setting = AppSettings::ColoredHelp)]
 pub(crate) struct Config {
     /// what kind of terminal coloring to use
     #[structopt(short, long, possible_values = &["ansi", "rgb", "none"])]

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -9,11 +9,11 @@ use structopt::StructOpt;
 #[structopt(name = "pipes-rs")]
 pub(crate) struct Config {
     /// “ansi”, “rgb” or “none”
-    #[structopt(short, long)]
+    #[structopt(short, long, possible_values = &["ansi", "rgb", "none"])]
     color_mode: Option<ColorMode>,
 
     /// “default”, “darker”, “pastel” or “matrix”
-    #[structopt(long)]
+    #[structopt(long, possible_values = &["default", "darker", "pastel", "matrix"])]
     palette: Option<Palette>,
 
     /// delay between frames in milliseconds

--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -30,11 +30,11 @@ pub(crate) struct Config {
     kinds: Option<PresetKindSet>,
 
     /// whether to use bold
-    #[structopt(short, long, possible_values = &["true", "false"])]
+    #[structopt(short, long, possible_values = &["true", "false"], value_name = "boolean")]
     bold: Option<bool>,
 
     /// whether pipes should retain style after hitting the edge
-    #[structopt(short, long, possible_values = &["true", "false"])]
+    #[structopt(short, long, possible_values = &["true", "false"], value_name = "boolean")]
     inherit_style: Option<bool>,
 
     /// number of pipes


### PR DESCRIPTION
This does not affect error messages when setting an incorrect colour mode or palette from the config file, only from the CLI.

Before:

<img width="715" alt="Screen Shot 2021-04-17 at 4 54 51 pm" src="https://user-images.githubusercontent.com/31783266/115104716-a1e8c300-9f9d-11eb-9697-40d3f50bf398.png">

After:

<img width="503" alt="Screen Shot 2021-04-17 at 4 54 31 pm" src="https://user-images.githubusercontent.com/31783266/115104710-96959780-9f9d-11eb-9caf-02d9efbba3c4.png">
