### PR TITLE
[Merged by Bors] - Process events inline during the main runloop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,15 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,15 +532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +554,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "crossterm",
- "flume",
  "unicode-width",
 ]
 

--- a/crates/pipes-rs/src/lib.rs
+++ b/crates/pipes-rs/src/lib.rs
@@ -69,9 +69,9 @@ impl App {
     }
 
     pub fn tick_loop(&mut self, pipes: &mut Vec<Pipe>) -> anyhow::Result<ControlFlow> {
-        match self.terminal.get_event() {
-            Some(Event::Reset) => return Ok(ControlFlow::Reset),
+        match self.terminal.get_event()? {
             Some(Event::Exit) => return Ok(ControlFlow::Break),
+            Some(Event::Reset) => return Ok(ControlFlow::Reset),
             None => {}
         }
 

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -8,7 +8,3 @@ version = "0.0.0"
 anyhow = "1.0.70"
 crossterm = "0.26.1"
 unicode-width = "0.1.10"
-
-[dependencies.flume]
-default_features = false
-version = "0.10.14"

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -7,7 +7,7 @@ use crossterm::{cursor, queue, style, terminal};
 use screen::Screen;
 use std::io::{self, Write};
 use std::num::NonZeroUsize;
-use std::thread;
+use std::time::Duration;
 use unicode_width::UnicodeWidthChar;
 
 pub struct Terminal {
@@ -15,7 +15,6 @@ pub struct Terminal {
     stdout: io::StdoutLock<'static>,
     max_char_width: u16,
     size: (u16, u16),
-    events_rx: flume::Receiver<EventWithData>,
 }
 
 impl Terminal {
@@ -33,46 +32,11 @@ impl Terminal {
 
         let screen = Screen::new(size.0 as usize, size.1 as usize);
 
-        let (events_tx, events_rx) = flume::unbounded();
-
-        thread::spawn(move || {
-            loop {
-                let Ok(event) = event::read() else { continue; };
-                match event {
-                    CrosstermEvent::Resize(width, height) => events_tx
-                        .send(EventWithData::Resized { width, height })
-                        .unwrap(),
-
-                    CrosstermEvent::Key(
-                        KeyEvent {
-                            code: KeyCode::Char('c'),
-                            modifiers: KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Press,
-                            ..
-                        }
-                        | KeyEvent {
-                            code: KeyCode::Char('q'),
-                            kind: KeyEventKind::Press,
-                            ..
-                        },
-                    ) => events_tx.send(EventWithData::Exit).unwrap(),
-
-                    CrosstermEvent::Key(KeyEvent {
-                        code: KeyCode::Char('r'),
-                        ..
-                    }) => events_tx.send(EventWithData::Reset).unwrap(),
-
-                    _ => {} // ignore all other events
-                }
-            }
-        });
-
         Ok(Self {
             screen,
             stdout,
             max_char_width,
             size,
-            events_rx,
         })
     }
 
@@ -170,15 +134,37 @@ impl Terminal {
         Ok(())
     }
 
-    pub fn get_event(&mut self) -> Option<Event> {
-        match self.events_rx.try_recv().ok() {
-            Some(EventWithData::Exit) => Some(Event::Exit),
-            Some(EventWithData::Reset) => Some(Event::Reset),
-            Some(EventWithData::Resized { width, height }) => {
+    pub fn get_event(&mut self) -> anyhow::Result<Option<Event>> {
+        if !event::poll(Duration::ZERO)? {
+            return Ok(None);
+        }
+
+        match event::read()? {
+            CrosstermEvent::Resize(width, height) => {
                 self.resize(width, height);
-                Some(Event::Reset)
+                Ok(Some(Event::Reset))
             }
-            None => None,
+
+            CrosstermEvent::Key(
+                KeyEvent {
+                    code: KeyCode::Char('c'),
+                    modifiers: KeyModifiers::CONTROL,
+                    kind: KeyEventKind::Press,
+                    ..
+                }
+                | KeyEvent {
+                    code: KeyCode::Char('q'),
+                    kind: KeyEventKind::Press,
+                    ..
+                },
+            ) => Ok(Some(Event::Exit)),
+
+            CrosstermEvent::Key(KeyEvent {
+                code: KeyCode::Char('r'),
+                ..
+            }) => Ok(Some(Event::Reset)),
+
+            _ => Ok(None),
         }
     }
 
@@ -228,10 +214,4 @@ impl From<Color> for style::Color {
 pub enum Event {
     Exit,
     Reset,
-}
-
-enum EventWithData {
-    Exit,
-    Reset,
-    Resized { width: u16, height: u16 },
 }


### PR DESCRIPTION
Previously we’d process events in a worker thread, which passed events over a channel to the main thread. This is unnecessarily complex; instead, let’s just poll for events inline during the main runloop.