### PR TITLE
Add default deserialization for `license` field of config

### DIFF
--- a/crates/pipes-rs/src/config.rs
+++ b/crates/pipes-rs/src/config.rs
@@ -60,6 +60,7 @@ pub struct Config {
 
     /// Print license
     #[arg(long)]
+    #[serde(default)]
     pub license: bool,
 }
 


### PR DESCRIPTION
Easy fix to not require the `license` field in a config file

Fixes #125