### PR TITLE
Reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 members = ["crates/*"]
 resolver = "2"
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
+panic = "abort"
 codegen-units = 1
 lto = "fat"
+strip = true
+opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ panic = "abort"
 codegen-units = 1
 lto = "fat"
 strip = true
-opt-level = "z"


### PR DESCRIPTION
This PR reduces the size of a `aarch64-apple-darwin` release binary from 1MB to 628KB.

* I enabled abort on panic in debug builds so that any problems caused by this are caught early. If it poses a problem during debugging it’s always possible to disable temporarily.
* Removing symbols shouldn’t be an issue for release builds.
* I changed the optimization level from `3` to `z` so LLVM optimizes for size rather than speed. pipes-rs is I/O-bound as it is, so I think we should value binary size over raw throughput (which is likely memory-bound anyway, lol).

@lhvy would it be too much trouble for you to test this on a Windows machine?