### PR TITLE
Remove etcetera dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,7 +207,7 @@ name = "pipes-rs"
 version = "1.6.2"
 dependencies = [
  "anyhow",
- "etcetera",
+ "home",
  "mimalloc",
  "model",
  "rng",

--- a/crates/pipes-rs/Cargo.toml
+++ b/crates/pipes-rs/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.6.2"
 
 [dependencies]
 anyhow = "1.0.70"
-etcetera = "0.8.0"
+home = "0.5.5"
 mimalloc = { version = "0.1.36", default-features = false }
 model = { path = "../model" }
 rng = { path = "../rng" }


### PR DESCRIPTION
Using a crates.io dependency for code this trivial is pointless.