### PR TITLE
Enable Hardened Runtime on macOS

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -63,6 +63,7 @@ jobs:
       - name: Create macOS archive
         run: |
           lipo -create -output ./${{ env.RELEASE_BIN }}-mac-universal ./target/x86_64-apple-darwin/release/${{ env.RELEASE_BIN }} ./target/aarch64-apple-darwin/release/${{ env.RELEASE_BIN }}
+          codesign --sign - --options runtime ./${{ env.RELEASE_BIN }}-mac-universal
           tar -czvf ./${{ env.RELEASE_BIN }}-mac-universal.tar.gz ./${{ env.RELEASE_BIN }}-mac-universal
         if: matrix.os == 'macos-latest'
 


### PR DESCRIPTION
Using the Hardened Runtime without any exceptions set means pipes-rs cannot access the user’s camera, microphone, location, address book, calendar or photo library. Moreover, a third party can no longer inject code into pipes-rs by:

- modifying dynamic libraries that pipes-rs uses
- using the macOS equivalent of `LD_PRELOAD`
- exploiting bugs in runtime machine code generation
- attaching a debugger and patching the program as it’s running

If someone really really needs to debug a release build (like that’s ever gonna happen lol) then removing the signature from the binary and signing it again without the Hardened Runtime is easy enough:

```
$ codesign --remove-signature $(which pipes-rs)
$ codesign --sign - $(which pipes-rs)
```