### PR TITLE
Add support for CLI help via -h

### DIFF
--- a/crates/pipes-rs/src/main.rs
+++ b/crates/pipes-rs/src/main.rs
@@ -45,7 +45,7 @@ fn parse_args(config: &mut Config) {
                 process::exit(0);
             }
 
-            "--help" => {
+            "--help" | "-h" => {
                 println!("{}", include_str!("usage"));
                 process::exit(0);
             }


### PR DESCRIPTION
I noticed that if you run -h for the help command it ends up with an error because it wants an option. So I added -h to the match arm in parse_args.